### PR TITLE
Handle the file not being able to be loaded

### DIFF
--- a/src/running other files.lua
+++ b/src/running other files.lua
@@ -1,2 +1,8 @@
-local s = loadfile( FILENAME )
-s( args[1], args[2], ... args[n] )
+local s, err = loadfile( FILENAME )
+if not s then
+    error( err, 0 )
+end
+s( unpack( args ) )
+
+-- similar to:
+-- assert( loadfile( FILENAME ) )( unpack( args ) )


### PR DESCRIPTION
If the file can't be loaded, loadfile will return nil, and the subsequent call (previously line 2) will error with "attempt to call nil". This errors with the correct error message.